### PR TITLE
Add citation to semver.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,3 +207,7 @@ Related
     "[Eternal compatibility in theory](The_Monad.Reader/Issue2/EternalCompatibilityInTheory "wikilink"),"
     [The Monad.Reader](The Monad.Reader "wikilink"),
     [Issue 2](The Monad.Reader/Issue2 "wikilink")
+-   [Semantics Versioning](http://semver.org/), 
+    a widely adopted cross-language standard that gives nearly identical 
+    meanings to _major_ and _minor_ versions, though using only one 
+    digit for the major version.


### PR DESCRIPTION
This document does not reference [Semantic Versioning](http://semver.org). In my experience, this standard is generally accepted for Javascript, Python, Ruby, Java, and generally reflects the practice of open source packages outside the Haskell ecosystem.

The only significant difference to me is our use of two digits for the major version number (and I don't really understand the origin of this or why it persists)