### PR TITLE
Use Hakyll defaults to restore syntax highlighting

### DIFF
--- a/src/site.hs
+++ b/src/site.hs
@@ -34,8 +34,10 @@ main = hakyll $ do
 --------------------------------------------------------------------------------
 -- | Our own pandoc compiler.
 pvpPandocCompiler :: Compiler (Item String)
-pvpPandocCompiler =
-    pandocCompilerWithTransform Pandoc.def Pandoc.def addAnchors
+pvpPandocCompiler = pandocCompilerWithTransform
+    defaultHakyllReaderOptions
+    defaultHakyllWriterOptions
+    addAnchors
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This is turned on in Hakyll's default settings but not in Pandoc's.