### PR TITLE
Change diagram to suggest more common numbering progression

### DIFF
--- a/pvp-decision-tree.svg
+++ b/pvp-decision-tree.svg
@@ -966,13 +966,13 @@
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        xml:space="preserve"><tspan
          y="553.73535"
-         x="399.20001"
+         x="395.20001"
          id="tspan11894"
-         sodipodi:role="line">Your new release</tspan><tspan
+         sodipodi:role="line">Your new release version</tspan><tspan
          y="568.73535"
-         x="399.20001"
+         x="395.20001"
          sodipodi:role="line"
-         id="tspan11898">version should be,</tspan><tspan
+         id="tspan11898">should be at least,</tspan><tspan
          id="tspan11896"
          y="583.73535"
          x="399.20001"

--- a/pvp-decision-tree.svg
+++ b/pvp-decision-tree.svg
@@ -912,7 +912,7 @@
    id="tspan11854"
    style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#5ccb4d;fill-opacity:1">(B+1) </tspan>. <tspan
    id="tspan11856"
-   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#cb4d4d;fill-opacity:1">C</tspan></tspan></text>
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#cb4d4d;fill-opacity:1">0</tspan></tspan></text>
     <text
        sodipodi:linespacing="125%"
        id="text11858"
@@ -927,9 +927,9 @@
    id="tspan11862"
    style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#4d6bcb;fill-opacity:1">(A+1) </tspan>. <tspan
    id="tspan11864"
-   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#5ccb4d;fill-opacity:1">B </tspan>. <tspan
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#5ccb4d;fill-opacity:1">0 </tspan>. <tspan
    id="tspan11866"
-   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#cb4d4d;fill-opacity:1">C</tspan></tspan></text>
+   style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:15px;line-height:125%;font-family:Sans;-inkscape-font-specification:'Sans, Italic';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#cb4d4d;fill-opacity:1">0</tspan></tspan></text>
     <text
        xml:space="preserve"
        style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:125%;font-family:Sans;-inkscape-font-specification:Sans;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"


### PR DESCRIPTION
Possibly related to issue #14.

Previously diagram seemed to suggest that changes should be

0.1.1 -> 0.2.1
   or -> 1.1.1

instead of
      -> 0.2.0
   or -> 1.0.0

which is not how package versioning on Hackage seems to work…

Rest of the text does not seem to specify what should happen with numbers "under bump".