### PR TITLE
Fix typo in 'Leaking instances' example code

### DIFF
--- a/v1.1/pvp-specification.md
+++ b/v1.1/pvp-specification.md
@@ -131,7 +131,7 @@ f = return . show
 Package C, depends on package B:
 
 ``` {.haskell}
-module Package C where
+module PackageC where
 
 import PackageB
 


### PR DESCRIPTION
There is a superfluous space in `module Package C where`.