### PR TITLE
Update PVP specification to mention non-leading zeros

### DIFF
--- a/v1.0/pvp-specification.md
+++ b/v1.0/pvp-specification.md
@@ -38,8 +38,7 @@ A package version number **SHOULD** have the form *A.B.C*, and **MAY**
 optionally have any number of additional components, for example 2.1.0.4
 (in this case, *A*=2, *B*=1, *C=0*). This policy defines the meaning of
 the first three components *A-C*, the other components can be used in
-any way the package maintainer sees fit. Components are non-negative
-integers, and MUST NOT contain leading zeroes.
+any way the package maintainer sees fit.
 
 Version number ordering is already defined by Cabal as the lexicographic
 ordering of the components. For example, 2.0.1 \> 1.3.2, and 2.0.1.0 \> 2.0.1.

--- a/v1.0/pvp-specification.md
+++ b/v1.0/pvp-specification.md
@@ -38,7 +38,8 @@ A package version number **SHOULD** have the form *A.B.C*, and **MAY**
 optionally have any number of additional components, for example 2.1.0.4
 (in this case, *A*=2, *B*=1, *C=0*). This policy defines the meaning of
 the first three components *A-C*, the other components can be used in
-any way the package maintainer sees fit.
+any way the package maintainer sees fit. Components are non-negative
+integers, and MUST NOT contain leading zeroes.
 
 Version number ordering is already defined by Cabal as the lexicographic
 ordering of the components. For example, 2.0.1 \> 1.3.2, and 2.0.1.0 \> 2.0.1.

--- a/v1.1/pvp-specification.md
+++ b/v1.1/pvp-specification.md
@@ -41,7 +41,8 @@ A package version number **SHOULD** have the form *A.B.C*, and **MAY**
 optionally have any number of additional components, for example 2.1.0.4
 (in this case, *A*=2, *B*=1, *C=0*). This policy defines the meaning of
 the first three components *A-C*, the other components can be used in
-any way the package maintainer sees fit.
+any way the package maintainer sees fit. Components are non-negative
+integers, and MUST NOT contain leading zeroes.
 
 Version number ordering is already defined by Cabal as the lexicographic
 ordering of the components. For example, 2.0.1 \> 1.3.2, and 2.0.1.0 \> 2.0.1.


### PR DESCRIPTION
Wasn't sure where to put this. Feel free to suggest moving it elsewhere. It didn't seem like it fit in the bullet points. Based on a conversation in the Haskell Foundation slack: https://haskell-foundation.slack.com/archives/C01PKJ9QKJ8/p1640106505142800