### PR TITLE
Clarify role of the FAQ

### DIFF
--- a/pvp-faq.md
+++ b/pvp-faq.md
@@ -12,6 +12,11 @@ If you have a question not addressed by the FAQ entries, feel free to
 post your question in the
 [PVP Issue Tracker](https://github.com/haskell/pvp/issues).
 
+The FAQ is not an authoritative source of interpretation for the PVP specification.
+Instead it is an attempt to provide insights. The source of truth is always and only
+the specification text. As this is a historical work-in-progress document, it may
+contain opinions not directly reflected in the proper specification.
+
 ## SemVer
 
 ### How does the PVP relate to [Semantic Versioning (SemVer)](http://semver.org)?


### PR DESCRIPTION
## Motivation

The FAQ has been frequently brought up in arguments about PVP compliance as an authoritative source on how to interpret the main specification text, even if the main text does not allow the same conclusions.

E.g.: https://github.com/haskell-infra/hackage-trustees/issues/375#issuecomment-1815906394

## Reasoning

A specification stands on its own and must be interpreted only through the specification text. Ambiguities and imprecisions in specs are rarely an oversight, but intended, in order to allow different implementations/approaches.

An FAQ serves to give more insights into a specification and is not there to fix insufficiently worded sections, nor to be an authoritative source of interpretation. Such sections need to be fixed in the spec text, not be amended by an FAQ.

Additionally, the FAQ is not even versioned, making it even more questionable to use as an authoritative source for interpretation.